### PR TITLE
Optional storage engine tests, fixed up broken specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/*
+spec/test_these_engines.rb

--- a/README.rdoc
+++ b/README.rdoc
@@ -33,4 +33,5 @@ To test and develop this gem, additional requirements are:
 * mongo
 * redis
 
-You will need to have {Tokyo Cabinet}[http://fallabs.com/tokyocabinet/], {MongoDB}[http://www.mongodb.org/], and {Redis}[http://code.google.com/p/redis/] installed on your system and running.
+You will need to have {Tokyo Cabinet}[http://fallabs.com/tokyocabinet/], {MongoDB}[http://www.mongodb.org/], and {Redis}[http://code.google.com/p/redis/] installed on your system and running if you intend to test these storage engines.
+You may add spec/testing_these_engines.rb and redefine $TESTING_STORAGE_ENGINES to specify which engines to test

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -9,13 +9,8 @@ module Anemone
       end
 
       it "should still return a Page if an exception occurs during the HTTP connection" do
-        class HTTP
-          def refresh_connection
-            raise "test exception"
-          end
-        end
-
-        http = Anemone::HTTP.new
+        http = HTTP.new
+        http.should_receive(:refresh_connection).once.and_raise(RuntimeError)
         http.fetch_page(SPEC_DOMAIN).should be_an_instance_of(Page)
       end
 

--- a/spec/page_store_spec.rb
+++ b/spec/page_store_spec.rb
@@ -1,5 +1,5 @@
 require File.dirname(__FILE__) + '/spec_helper'
-%w[pstore tokyo_cabinet mongodb redis].each { |file| require "anemone/storage/#{file}.rb" }
+require_storage_engines $TESTABLE_STORAGE_ENGINES
 
 module Anemone
   describe PageStore do
@@ -92,59 +92,67 @@ module Anemone
       end
     end
 
-    describe Storage::PStore do
-      it_should_behave_like "page storage"
+    if testing? 'pstore'
+      describe Storage::PStore do
+        it_should_behave_like "page storage"
 
-      before(:each) do
-        @test_file = 'test.pstore'
-        File.delete(@test_file) if File.exists?(@test_file)
-        @opts = {:storage => Storage.PStore(@test_file)}
-      end
+        before(:each) do
+          @test_file = 'test.pstore'
+          File.delete(@test_file) if File.exists?(@test_file)
+          @opts = {:storage => Storage.PStore(@test_file)}
+        end
 
-      after(:all) do
-        File.delete(@test_file) if File.exists?(@test_file)
-      end
-    end
-
-    describe Storage::TokyoCabinet do
-      it_should_behave_like "page storage"
-
-      before(:each) do
-        @test_file = 'test.tch'
-        File.delete(@test_file) if File.exists?(@test_file)
-        @opts = {:storage => @store = Storage.TokyoCabinet(@test_file)}
-      end
-
-      after(:each) do
-        @store.close
-      end
-
-      after(:all) do
-        File.delete(@test_file) if File.exists?(@test_file)
+        after(:all) do
+          File.delete(@test_file) if File.exists?(@test_file)
+        end
       end
     end
 
-    describe Storage::MongoDB do
-      it_should_behave_like "page storage"
+    if testing? 'tokyo_cabinet'
+      describe Storage::TokyoCabinet do
+        it_should_behave_like "page storage"
 
-      before(:each) do
-        @opts = {:storage => @store = Storage.MongoDB}
-      end
+        before(:each) do
+          @test_file = 'test.tch'
+          File.delete(@test_file) if File.exists?(@test_file)
+          @opts = {:storage => @store = Storage.TokyoCabinet(@test_file)}
+        end
 
-      after(:each) do
-        @store.close
+        after(:each) do
+          @store.close
+        end
+
+        after(:all) do
+          File.delete(@test_file) if File.exists?(@test_file)
+        end
       end
     end
 
-    describe Storage::Redis do
-      it_should_behave_like "page storage"
+    if testing? 'mongodb'
+      describe Storage::MongoDB do
+        it_should_behave_like "page storage"
 
-      before(:each) do
-        @opts = {:storage => @store = Storage.Redis}
+        before(:each) do
+          @opts = {:storage => @store = Storage.MongoDB}
+        end
+
+        after(:each) do
+          @store.close
+        end
       end
+    end
 
-      after(:each) do
-        @store.close
+    if testing? 'redis'
+      describe Storage::Redis do
+        it_should_behave_like "page storage"
+
+        before(:each) do
+          @opts = {:storage => @store = Storage.Redis}
+        end
+
+        after(:each) do
+          @store.close
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,17 @@ $:.unshift(File.dirname(__FILE__) + '/../lib/')
 require 'anemone'
 
 SPEC_DOMAIN = 'http://www.example.com/'
+
+# Don't modify this line - add the file spec/test_these_engines.rb and redefine this global
+# to include/exclude custom engines if you don't have all the gems.
+$TESTABLE_STORAGE_ENGINES = %w[redis pstore tokyo_cabinet mongodb]
+optional_test_restrictions_file = File.dirname(__FILE__) + '/test_these_engines.rb'
+require optional_test_restrictions_file if File.exist?(optional_test_restrictions_file)
+
+def testing?(engine_name)
+  $TESTABLE_STORAGE_ENGINES.include?(engine_name)
+end
+
+def require_storage_engines *engines
+  engines.flatten.each { |engine| require "anemone/storage/#{engine}.rb" if testing?(engine) }
+end


### PR DESCRIPTION
Hi,

As per other message - fixed specs broken due to redefinition of HTTP.refresh_connection (replaced with mock) and also made testing of any/all storage engines optional.  Default behaviour is to test every storage engine as before, but if you add a `spec/test_these_engines.rb` and redefine `$TESTING_STORAGE_ENGINES` to contain only what you're interested in (it's in the `.gitignore`) you can restrict testing to only those gems you have (Redis in my case).

Hopefully this gets me into a state where I can add the features I _really_ want - canonical URL support and the ability to treat more than one domain as the same site.

Cheers,

Russ
