### PR TITLE
features & bug fixes for anemone v0.5.0

### DIFF
--- a/lib/anemone/http.rb
+++ b/lib/anemone/http.rb
@@ -135,6 +135,10 @@ module Anemone
 
     def refresh_connection(url)
       http = Net::HTTP.new(url.host, url.port)
+      if @opts[:read_timeout] then
+        http.read_timeout = @opts[:read_timeout]
+      end
+      
       if url.scheme == 'https'
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/anemone/http.rb
+++ b/lib/anemone/http.rb
@@ -116,7 +116,7 @@ module Anemone
         response_time = ((finish - start) * 1000).round
         @cookie_store.merge!(response['Set-Cookie']) if accept_cookies?
         return response, response_time
-      rescue EOFError
+      rescue EOFError, Timeout::Error
         refresh_connection(url)
         retries += 1
         retry unless retries > 3

--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -47,8 +47,10 @@ module Anemone
       @response_time = params[:response_time]
       @body = params[:body]
       @error = params[:error]
-
+        
       @fetched = !params[:code].nil?
+
+    
     end
 
     #
@@ -167,8 +169,8 @@ module Anemone
 
     def to_hash
       {'url' => @url.to_s,
-       'headers' => Marshal.dump(@headers),
-       'data' => Marshal.dump(@data),
+       'headers' => self.to_hash_struct(@headers),
+       'data' => self.to_hash_struct(@data),
        'body' => @body,
        'links' => links.map(&:to_s), 
        'code' => @code,
@@ -182,8 +184,8 @@ module Anemone
 
     def self.from_hash(hash)
       page = self.new(URI(hash['url']))
-      {'@headers' => Marshal.load(hash['headers']),
-       '@data' => Marshal.load(hash['data']),
+      {'@headers' => page.from_hash_struct(hash['headers']),
+       '@data' => page.from_hash_struct(hash['data']),
        '@body' => hash['body'],
        '@links' => hash['links'].map { |link| URI(link) },
        '@code' => hash['code'].to_i,
@@ -198,5 +200,14 @@ module Anemone
       end
       page
     end
+    
+    def from_hash_struct(data)
+      Marshal.load(data)
+    end
+    
+    def to_hash_struct(data)
+      Marshal.dump(data)
+    end
+    
   end
 end

--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -169,8 +169,8 @@ module Anemone
 
     def to_hash
       {'url' => @url.to_s,
-       'headers' => self.to_hash_struct(@headers),
-       'data' => self.to_hash_struct(@data),
+       'headers' => Marshal.dump(@headers),
+       'data' => Marshal.dump(@data),
        'body' => @body,
        'links' => links.map(&:to_s), 
        'code' => @code,
@@ -184,8 +184,8 @@ module Anemone
 
     def self.from_hash(hash)
       page = self.new(URI(hash['url']))
-      {'@headers' => page.from_hash_struct(hash['headers']),
-       '@data' => page.from_hash_struct(hash['data']),
+      {'@headers' => Marshal.load(hash['headers']),
+       '@data' => Marshal.load(hash['data']),
        '@body' => hash['body'],
        '@links' => hash['links'].map { |link| URI(link) },
        '@code' => hash['code'].to_i,
@@ -199,14 +199,6 @@ module Anemone
         page.instance_variable_set(var, value)
       end
       page
-    end
-    
-    def from_hash_struct(data)
-      Marshal.load(data)
-    end
-    
-    def to_hash_struct(data)
-      Marshal.dump(data)
     end
     
   end

--- a/lib/anemone/page_store.rb
+++ b/lib/anemone/page_store.rb
@@ -155,6 +155,10 @@ module Anemone
         return links
       end
     end
+    
+    def non_fetched_urls(limit = 10)
+      @storage.non_fetched_urls(limit)
+    end
 
   end
 end

--- a/lib/anemone/storage.rb
+++ b/lib/anemone/storage.rb
@@ -4,7 +4,7 @@ module Anemone
     def self.Hash(*args)
       hash = Hash.new(*args)
       # add close method for compatibility with Storage::Base
-      class << hash; def close; end; end
+      class << hash; def close; end; def non_fetched_urls; end; end
       hash
     end
 

--- a/lib/anemone/storage.rb
+++ b/lib/anemone/storage.rb
@@ -13,16 +13,16 @@ module Anemone
       self::PStore.new(*args)
     end
 
-    def self.TokyoCabinet(file = 'anemone.tch')
+    def self.TokyoCabinet(file = 'anemone.tch', remove_existing = false)
       require 'anemone/storage/tokyo_cabinet'
-      self::TokyoCabinet.new(file)
+      self::TokyoCabinet.new(file, remove_existing)
     end
 
-    def self.MongoDB(mongo_db = nil, collection_name = 'pages')
+    def self.MongoDB(mongo_db = nil, collection_name = 'pages', remove_existing = false)
       require 'anemone/storage/mongodb'
       mongo_db ||= Mongo::Connection.new.db('anemone')
       raise "First argument must be an instance of Mongo::DB" unless mongo_db.is_a?(Mongo::DB)
-      self::MongoDB.new(mongo_db, collection_name)
+      self::MongoDB.new(mongo_db, collection_name, remove_existing)
     end
 
     def self.Redis(opts = {})

--- a/lib/anemone/storage/base.rb
+++ b/lib/anemone/storage/base.rb
@@ -69,6 +69,10 @@ module Anemone
         rescue
           raise GenericError, $!
       end
+  
+      def non_fetched_urls(limit = 10)
+        @adap.non_fetched_urls(limit)
+      end
 
     end
   end

--- a/lib/anemone/storage/mongodb.rb
+++ b/lib/anemone/storage/mongodb.rb
@@ -72,6 +72,17 @@ module Anemone
         !!@collection.find_one('url' => url.to_s)
       end
 
+      def non_fetched_urls(limit = 10)
+        urls = []
+        @collection.find({'fetched' => false}, {:fields => 'url', :limit => limit}) do |cursor|
+          cursor.each do |doc|
+            urls.push URI(doc['url'])
+          end
+        end
+
+        urls   
+      end
+
       def close
         @db.connection.close
       end
@@ -84,7 +95,6 @@ module Anemone
         end
         Page.from_hash(hash)
       end
-
     end
   end
 end

--- a/lib/anemone/storage/mongodb.rb
+++ b/lib/anemone/storage/mongodb.rb
@@ -11,11 +11,13 @@ module Anemone
 
       BINARY_FIELDS = %w(body headers data)
 
-      def initialize(mongo_db, collection_name)
+      def initialize(mongo_db, collection_name, remove_existing = true)
         @db = mongo_db
         @collection = @db[collection_name]
-        @collection.remove
-        @collection.create_index 'url'
+        if remove_existing
+          @collection.remove
+        end
+        @collection.ensure_index 'url'
       end
 
       def [](url)

--- a/lib/anemone/storage/pstore.rb
+++ b/lib/anemone/storage/pstore.rb
@@ -46,6 +46,10 @@ module Anemone
         self
       end
 
+      def non_fetched_urls(limit = 10)
+        raise GenericError, $!
+      end
+
       def close; end
 
     end

--- a/lib/anemone/storage/pstore.rb
+++ b/lib/anemone/storage/pstore.rb
@@ -46,9 +46,7 @@ module Anemone
         self
       end
 
-      def non_fetched_urls(limit = 10)
-        raise GenericError, $!
-      end
+      def non_fetched_urls(limit = 10); end
 
       def close; end
 

--- a/lib/anemone/storage/pstore.rb
+++ b/lib/anemone/storage/pstore.rb
@@ -8,8 +8,11 @@ module Anemone
 
       def_delegators :@keys, :has_key?, :keys, :size
 
-      def initialize(file)
-        File.delete(file) if File.exists?(file)
+      def initialize(file, remove_existing = false)
+        if File.exists?(file) && remove_existing
+          File.delete(file) 
+        end
+        
         @store = ::PStore.new(file)
         @keys = {}
       end

--- a/lib/anemone/storage/redis.rb
+++ b/lib/anemone/storage/redis.rb
@@ -9,7 +9,9 @@ module Anemone
       def initialize(opts = {})
         @redis = ::Redis.new(opts)
         @key_prefix = opts[:key_prefix] || 'anemone'
-        keys.each { |key| delete(key) }
+        if opts[:remove_existing]
+          keys.each { |key| delete(key) }
+        end
       end
 
       def [](key)

--- a/lib/anemone/storage/redis.rb
+++ b/lib/anemone/storage/redis.rb
@@ -69,6 +69,19 @@ module Anemone
         @redis.quit
       end
 
+      def non_fetched_urls(limit = 10)
+        urls = []
+        rkeys = @redis.keys("#{@key_prefix}:pages:*")
+        rkeys.each do |rkey|
+          hash = @redis.hgetall(rkey)
+          if hash['fetched'] == false then
+            urls.push URI(hash['url'])              
+            break if urls.count == limit 
+          end
+        end          
+        urls
+      end
+
       private
 
       def load_value(hash)

--- a/lib/anemone/storage/tokyo_cabinet.rb
+++ b/lib/anemone/storage/tokyo_cabinet.rb
@@ -14,10 +14,14 @@ module Anemone
 
       def_delegators :@db, :close, :size, :keys, :has_key?
 
-      def initialize(file)
+      def initialize(file, remove_existing = false)
         raise "TokyoCabinet filename must have .tch extension" if File.extname(file) != '.tch'
         @db = ::TokyoCabinet::HDB::new
-        @db.open(file, ::TokyoCabinet::HDB::OWRITER | ::TokyoCabinet::HDB::OCREAT)
+        if remove_existing 
+          @db.open(file, ::TokyoCabinet::HDB::OWRITER | ::TokyoCabinet::HDB::OTRUNC)
+        else
+          @db.open(file, ::TokyoCabinet::HDB::OWRITER | ::TokyoCabinet::HDB::OCREAT)
+        end
         @db.clear
       end
 

--- a/lib/anemone/storage/tokyo_cabinet.rb
+++ b/lib/anemone/storage/tokyo_cabinet.rb
@@ -50,6 +50,10 @@ module Anemone
         self
       end
 
+      def non_fetched_urls(limit = 10)
+        raise GenericError, $!
+      end
+
       private
 
       def load_value(value)

--- a/lib/anemone/storage/tokyo_cabinet.rb
+++ b/lib/anemone/storage/tokyo_cabinet.rb
@@ -50,9 +50,7 @@ module Anemone
         self
       end
 
-      def non_fetched_urls(limit = 10)
-        raise GenericError, $!
-      end
+      def non_fetched_urls(limit = 10); end
 
       private
 


### PR DESCRIPTION
Hi Chris,
Awesome work with the Anemone spider.  I've made some enhancements and bug fixes that I felt would be helpful in the main branch.  I've tested these changes with everything but TokyoCabinet (I wasn't able to get it working on my system).  

I played around with some changes that were eventually rolled back so a summary of the final changes is below.  Please let me know what you think about them.

Thanks,
Mike

1) https://github.com/chriskite/anemone/issues#issue/7
- Added 'remove_existing' parameter to the storage classes so that so that it doesn't always wipe out the datastore. I left the default value to true for backwards compatibility.
- I also added 'resume' parameter so that even if the URLs initially requested has been visited, it will find URLs from the datastore that still need to be crawled.

2) Added a parameter to set the read_timeout for Net::HTTP.  Also added error handling so that when a read_timeout happens, it doesn't abort the entire crawl.

3) Add skip_query_string_like that works like skip_links_like except it is applied against the link.query. I found this useful for links that change settings or do other special actions to an otherwise normal page.

Thanks again for the great spider.  -Mike
