### PR TITLE
fixing double encoding issue

### DIFF
--- a/anemone.gemspec
+++ b/anemone.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = "anemone"
-  s.version = "0.5.0"
+  s.version = "0.5.0.2"
   s.author = "Chris Kite"
   s.homepage = "http://anemone.rubyforge.org"
   s.rubyforge_project = "anemone"

--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -260,6 +260,8 @@ module Anemone
     #
     def allowed(link)
       @opts[:obey_robots_txt] ? @robots.allowed?(link) : true
+    rescue
+      false
     end
 
     #

--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -139,7 +139,7 @@ module Anemone
       return nil if link.nil?
 
       # remove anchor
-      link = URI.encode(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,''))
+      link = URI.encode(URI.decode(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')))
 
       relative = URI(link)
       absolute = @url.merge(relative)


### PR DESCRIPTION
Links containing %20 are converted to %2520. It calls URI.encode on urls containing %20 which gets converted into %2520.
