### PR TITLE
URI escaping in page.rb/links

### DIFF
--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -62,7 +62,7 @@ module Anemone
       doc.search("//a[@href]").each do |a|
         u = a['href']
         next if u.nil? or u.empty?
-        abs = to_absolute(URI(u)) rescue next
+        abs = to_absolute(URI(URI.escape(u))) rescue next
         @links << abs if in_domain?(abs)
       end
       @links.uniq!


### PR DESCRIPTION
URIs can contain invalid characters if they are built by the website using article titles or similar. That does work when clicked in a browser, it does however result in an invalid link when crawled by Anemone.
I added URI.escape to avoid that. Tested on about 20 websites without issues.
