### PR TITLE
fix for nil redirect_to in redis entry

### DIFF
--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -190,7 +190,7 @@ module Anemone
        '@visited' => hash['visited'],
        '@depth' => hash['depth'].to_i,
        '@referer' => hash['referer'],
-       '@redirect_to' => URI(hash['redirect_to']),
+       '@redirect_to' => URI(hash['redirect_to'] || ''),
        '@response_time' => hash['response_time'].to_i,
        '@fetched' => hash['fetched']
       }.each do |var, value|

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -89,5 +89,11 @@ module Anemone
       converted.depth.should == page.depth
     end
 
+    it 'should handle a from_hash with a nil redirect_to' do
+      page_hash = @page.to_hash
+      page_hash['redirect_to'] = nil
+      lambda{Page.from_hash(page_hash)}.should_not raise_error(URI::InvalidURIError)
+    end
+
   end
 end


### PR DESCRIPTION
fixes exception raised when redirect_to is nil. can occur on load of a redis entry
