### PR TITLE
Fixes OutOfMemory error for large sites

### DIFF
--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -175,6 +175,15 @@ module Anemone
 
         @pages[page.url] = page
 
+		# if link_queue grows faster than threads can consume them
+		# pass until threads consumed enough links.
+		# Fixes OutOfMemory error when crawling large sites
+		# TEMPORARY FIX. (Is there a better solution?)
+		until link_queue.length < @opts[:threads]*10
+          Thread.pass
+          sleep 1.0
+        end
+		
         # if we are done with the crawl, tell the threads to end
         if link_queue.empty? and page_queue.empty?
           until link_queue.num_waiting == @tentacles.size


### PR DESCRIPTION
Occurs when crawling larges sites.

Issue: link_queue grows faster than threads consume links.

Fix: Wait until threads consumed enough links, then continue adding more to the queue.
