### PR TITLE
Fixes OutOfMemory error for large sites

### DIFF
--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -58,7 +58,7 @@ module Anemone
       :proxy_port => false,
       # HTTP read timeout in seconds
       :read_timeout => nil,
-      # disable support for larg-scale crawls
+      # disable support for larg-scale crawls. Activate if you run out of memory during crawls.
       :large_scale_crawl => false
     }
 
@@ -161,10 +161,6 @@ module Anemone
       @urls.each{ |url| link_queue.enq([url]) }
 
       @tentacles << Thread.new { Tentacle.new(link_queue, page_queue, @opts,1).run; }
-
-      until !page_queue.empty?
-        Thread.pass
-      end
 
       loop do
         page = page_queue.deq

--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -1,5 +1,4 @@
 require 'thread'
-require 'monitor'
 require 'robots'
 require 'anemone/tentacle'
 require 'anemone/page'

--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -175,6 +175,15 @@ module Anemone
 
         @pages[page.url] = page
 
+		# if link_queue grows faster than threads can consume them
+		# pass until threads consumed enough links.
+		# Fixes OutOfMemory error when crawling large sites
+		# TEMPORARY FIX. (Is there a better solution?)
+		until link_queue.length < @opts[:threads]*10
+          Thread.pass
+          sleep 1.0
+        end
+		
         # if we are done with the crawl, tell the threads to end
         if link_queue.empty? and page_queue.empty?
           until link_queue.num_waiting == @tentacles.size

--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -1,4 +1,5 @@
 require 'thread'
+require 'monitor'
 require 'robots'
 require 'anemone/tentacle'
 require 'anemone/page'
@@ -6,6 +7,7 @@ require 'anemone/exceptions'
 require 'anemone/page_store'
 require 'anemone/storage'
 require 'anemone/storage/base'
+require 'anemone/ext_queue'
 
 module Anemone
 
@@ -55,7 +57,9 @@ module Anemone
       # proxy server port number
       :proxy_port => false,
       # HTTP read timeout in seconds
-      :read_timeout => nil
+      :read_timeout => nil,
+      # disable support for larg-scale crawls
+      :large_scale_crawl => false
     }
 
     # Create setter methods for all options to be called from the crawl block
@@ -151,39 +155,37 @@ module Anemone
       @urls.delete_if { |url| !visit_link?(url) }
       return if @urls.empty?
 
-      link_queue = Queue.new
-      page_queue = Queue.new
+      link_queue = @opts[:large_scale_crawl] ? ExtQueue.new(10000,"link") : Queue.new
+      page_queue = @opts[:large_scale_crawl] ? ExtQueue.new(600,'page') : Queue.new
 
-      @opts[:threads].times do
-        @tentacles << Thread.new { Tentacle.new(link_queue, page_queue, @opts).run }
+      @urls.each{ |url| link_queue.enq([url]) }
+
+      @tentacles << Thread.new { Tentacle.new(link_queue, page_queue, @opts,1).run; }
+
+      until !page_queue.empty?
+        Thread.pass
       end
-
-      @urls.each{ |url| link_queue.enq(url) }
 
       loop do
         page = page_queue.deq
         @pages.touch_key page.url
-        puts "#{page.url} Queue: #{link_queue.size}" if @opts[:verbose]
-        do_page_blocks page
-        page.discard_doc! if @opts[:discard_page_bodies]
 
+        do_page_blocks page
+
+        page.discard_doc! if @opts[:discard_page_bodies]
         links = links_to_follow page
         links.each do |link|
           link_queue << [link, page.url.dup, page.depth + 1]
         end
-        @pages.touch_keys links
 
+        @pages.touch_keys links
         @pages[page.url] = page
 
-		# if link_queue grows faster than threads can consume them
-		# pass until threads consumed enough links.
-		# Fixes OutOfMemory error when crawling large sites
-		# TEMPORARY FIX. (Is there a better solution?)
-		until link_queue.length < @opts[:threads]*10
-          Thread.pass
-          sleep 1.0
+        # Add more threads if applicable
+        if link_queue.length > @tentacles.length*2 and @opts[:threads] > @tentacles.length
+          @tentacles << Thread.new { Tentacle.new(link_queue, page_queue, @opts, @tentacles.length+1).run; }
         end
-		
+
         # if we are done with the crawl, tell the threads to end
         if link_queue.empty? and page_queue.empty?
           until link_queue.num_waiting == @tentacles.size
@@ -197,7 +199,9 @@ module Anemone
       end
 
       @tentacles.each { |thread| thread.join }
+
       do_after_crawl_blocks
+
       self
     end
 

--- a/lib/anemone/ext_queue.rb
+++ b/lib/anemone/ext_queue.rb
@@ -3,21 +3,36 @@ require "yaml"
 require 'thread'
 
 class ExtQueue
+
+  #
+  # Create new Queue with on-demand external memory storage.
+  # Requires read-write access to working directory.
+  #
+  # The class is not preserving the order of elements
+  # as would be expected for a Queue.
+  #
+  # TODO: Modify this class to check for actual memory consumption rather than element count
+  #
+
   def initialize(max_elem_in_memory, prefix)
     @data = []
-    @data.taint
     @waiting=[]
-    @waiting.taint
 
     @q_max = 0
     @q_min = 0
-    @lock = Mutex.new
-    @max_elem = max_elem_in_memory
-    @partial = 2;
-    @num = (@max_elem / @partial).ceil
-    @prefix = prefix
-    self.taint
 
+    @lock = Mutex.new
+
+    @max_elem = max_elem_in_memory
+    @swap_fraction = 0.5;  # fraction of data to write to disk when exceeding the queue limit
+    @num = (@max_elem * @swap_fraction).ceil
+
+    # filename prefix for the storage
+    @prefix = prefix
+
+    @data.taint
+    @waiting.taint
+    self.taint
   end
 
 

--- a/lib/anemone/ext_queue.rb
+++ b/lib/anemone/ext_queue.rb
@@ -1,0 +1,131 @@
+require 'psych'
+require "yaml"
+require 'thread'
+
+class ExtQueue
+  def initialize(max_elem_in_memory, prefix)
+    @data = []
+    @data.taint
+    @waiting=[]
+    @waiting.taint
+
+    @q_max = 0
+    @q_min = 0
+    @lock = Mutex.new
+    @max_elem = max_elem_in_memory
+    @partial = 2;
+    @num = (@max_elem / @partial).ceil
+    @prefix = prefix
+    self.taint
+
+  end
+
+
+  ## Enqueue
+  def push(obj)
+    @lock.synchronize{
+      writeToDisk if @data.length>=@max_elem
+      @data.push obj
+      begin
+        t = @waiting.shift
+        t.wakeup if t
+      rescue ThreadError
+        retry
+      end
+    }
+    self
+  end
+
+  #
+  # Alias of push
+  #
+  alias << push
+
+  #
+  # Alias of push
+  #
+  alias enq push
+
+
+
+  #
+  # Retrieves data from the queue.  If the queue is empty, the calling thread is
+  # suspended until data is pushed onto the queue.  If +non_block+ is true, the
+  # thread isn't suspended, and an exception is raised.
+  #
+  def pop(non_block=false)
+    @lock.synchronize{
+      while true
+        if self.empty?
+          raise ThreadError, "queue empty" if non_block
+          @waiting.push Thread.current
+          @lock.sleep
+        else
+          readFromDisk if @data.empty? and (@q_min < @q_max)
+          return @data.shift
+        end
+      end
+    }
+  end
+
+  #
+  # Alias of pop
+  #
+  alias shift pop
+
+  #
+  # Alias of pop
+  #
+  alias deq pop
+
+
+
+  def clear
+    @lock.synchronize {
+      @data.clear
+      (@q_min..@q_max).each { |i| File.unlink("#{@prefix}#{i}.anemone") }
+      @q_min = 0
+      @q_max = 0
+    }
+  end
+
+  def length
+    @data.length
+  end
+
+  alias size length
+
+  def empty?
+    @data.empty? and @q_min==@q_max
+  end
+
+  #
+  # Returns the number of threads waiting on the queue.
+  #
+  def num_waiting
+    @waiting.size
+  end
+
+  private
+
+  def writeToDisk
+    File.open("#{@prefix}#{@q_max}.anemone","w+") do |file|
+      popped = @data.pop(@num)
+      popped.each { |elem| file.puts YAML::dump(elem) }
+      @q_max += 1
+    end
+  end
+
+  def readFromDisk
+    $/="\n\n"
+    f = File.open("#{@prefix}#{@q_min}.anemone","r")
+    f.each do |obj|
+      @data.unshift( YAML::load(obj) )
+    end
+    f.close
+    @q_min += 1
+    $/="\n"
+    File.unlink("#{@prefix}#{@q_min-1}.anemone");
+  end
+
+end


### PR DESCRIPTION
- Added support for external queues via :large_scale_crawl option. (Requires R/W permission for working dir)
- Improved Thread handling. All threads now properly start working on the crawl
