### PR TITLE
Fix default filename extension for the kyotocabinet adapter.

### DIFF
--- a/lib/anemone/storage.rb
+++ b/lib/anemone/storage.rb
@@ -18,7 +18,7 @@ module Anemone
       self::TokyoCabinet.new(file)
     end
 
-    def self.KyotoCabinet(file = 'anemone.tch')
+    def self.KyotoCabinet(file = 'anemone.kch')
       require 'anemone/storage/kyoto_cabinet'
       self::KyotoCabinet.new(file)
     end


### PR DESCRIPTION
The default filename for the kyotocabinet db file is using the wrong extension.
