### PR TITLE
Do not require rubygems in library code.

### DIFF
--- a/lib/anemone.rb
+++ b/lib/anemone.rb
@@ -1,2 +1,1 @@
-require 'rubygems'
 require 'anemone/core'


### PR DESCRIPTION
It's a good practice to not require rubygems in library code.

See http://guides.rubygems.org/patterns/#declaring-dependencies and
http://tomayko.com/writings/require-rubygems-antipattern for more info.
