### PR TITLE
Fix for URI::InvalidURIError: bad URI(is not URI?).

### DIFF
--- a/lib/anemone/http.rb
+++ b/lib/anemone/http.rb
@@ -112,7 +112,7 @@ module Anemone
 
           response, response_time = get_response(loc, referer)
           code = Integer(response.code)
-          redirect_to = response.is_a?(Net::HTTPRedirection) ? URI(response['location']).normalize : nil
+          redirect_to = response.is_a?(Net::HTTPRedirection) ? URI(URI.escape(response['location'])).normalize : nil
           yield response, code, loc, redirect_to, response_time
           limit -= 1
       end while (loc = redirect_to) && allowed?(redirect_to, url) && limit > 0


### PR DESCRIPTION
Fix for URI::InvalidURIError: bad URI(is not URI?). For example, URI('http://google.com/åäö') fails otherwise.
