### PR TITLE
Should allow redirects from non-www to www and vice versa.

### DIFF
--- a/lib/anemone/http.rb
+++ b/lib/anemone/http.rb
@@ -180,7 +180,7 @@ module Anemone
     # Allowed to connect to the requested url?
     #
     def allowed?(to_url, from_url)
-      to_url.host.nil? || (to_url.host == from_url.host)
+      to_url.host.nil? || (to_url.host.sub(/^www\./, '') == from_url.host.sub(/^www\./, ''))
     end
 
   end


### PR DESCRIPTION
Anemone should allow redirects from non-www to www and vice versa. Currently this is not the case.
