### PR TITLE
Give focus_crawl a chance to access page body before discarding it

### DIFF
--- a/lib/anemone/core.rb
+++ b/lib/anemone/core.rb
@@ -50,7 +50,7 @@ module Anemone
       :accept_cookies => false,
       # skip any link with a query string? e.g. http://foo.com/?u=user
       :skip_query_strings => false,
-      # proxy server hostname 
+      # proxy server hostname
       :proxy_host => nil,
       # proxy server port number
       :proxy_port => false,
@@ -164,10 +164,11 @@ module Anemone
         page = page_queue.deq
         @pages.touch_key page.url
         puts "#{page.url} Queue: #{link_queue.size}" if @opts[:verbose]
+
         do_page_blocks page
+        links = links_to_follow page
         page.discard_doc! if @opts[:discard_page_bodies]
 
-        links = links_to_follow page
         links.each do |link|
           link_queue << [link, page.url.dup, page.depth + 1]
         end
@@ -281,7 +282,7 @@ module Anemone
         false
       end
     end
-    
+
     #
     # Returns +true+ if *link* should not be visited because
     # it has a query string and +skip_query_strings+ is true.


### PR DESCRIPTION
For site-specific crawlers, it's fair enough to use `focus_crawl` like this:

```
anemone.focus_crawl do |page|
  if page.doc
    page.doc.search('.//a[@href]').map { |a| URI.parse(a[:href]) }
  else
    page.links
  end
end
```

However when using the `discard_page_bodies` option, `page.doc` is `nil` by the time we enter this block. In this pull request I've moved until after `focus_crawl` has been called.
