### PR TITLE
Avoid using URI.escape/unescape when Ruby 2.7 is running

### DIFF
--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -154,7 +154,12 @@ module Anemone
       return nil if link.nil?
 
       # remove anchor
-      link = URI.encode(URI.decode(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')))
+      if ruby27?
+        require 'cgi'
+        link = CGI.unescape(CGI.escape(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')))
+      else
+        link = URI.encode(URI.decode(link.to_s.gsub(/#[a-zA-Z0-9_-]*$/,'')))
+      end
 
       relative = URI(link)
       absolute = base ? base.merge(relative) : @url.merge(relative)
@@ -193,6 +198,10 @@ module Anemone
        'redirect_to' => @redirect_to.to_s,
        'response_time' => @response_time,
        'fetched' => @fetched}
+    end
+
+    def ruby27?
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
     end
 
     def self.from_hash(hash)

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -143,42 +143,46 @@ module Anemone
 
     it "should have a method to convert a relative url to an absolute one" do
       @page.should respond_to(:to_absolute)
-      
-      # Identity
-      @page.to_absolute(@page.url).should == @page.url
-      @page.to_absolute("").should == @page.url
-      
-      # Root-ness
-      @page.to_absolute("/").should == URI("#{SPEC_DOMAIN}")
-      
-      # Relativeness
-      relative_path = "a/relative/path"
-      @page.to_absolute(relative_path).should == URI("#{SPEC_DOMAIN}#{relative_path}")
-      
-      deep_page = @http.fetch_page(FakePage.new('home/deep', :links => '1').url)
-      upward_relative_path = "../a/relative/path"
-      deep_page.to_absolute(upward_relative_path).should == URI("#{SPEC_DOMAIN}#{relative_path}")
-      
-      # The base URL case
-      base_path = "path/to/base_url/"
-      base = "#{SPEC_DOMAIN}#{base_path}"
-      page = @http.fetch_page(FakePage.new('home', {:base => base}).url)
-      
-      # Identity
-      page.to_absolute(page.url).should == page.url
-      # It should revert to the base url
-      page.to_absolute("").should_not == page.url
 
-      # Root-ness
-      page.to_absolute("/").should == URI("#{SPEC_DOMAIN}")
-      
-      # Relativeness
-      relative_path = "a/relative/path"
-      page.to_absolute(relative_path).should == URI("#{base}#{relative_path}")
-      
-      upward_relative_path = "../a/relative/path"
-      upward_base = "#{SPEC_DOMAIN}path/to/"
-      page.to_absolute(upward_relative_path).should == URI("#{upward_base}#{relative_path}")      
+      [true, false].each do |bool|
+        @page.stub(:ruby27?).and_return(bool)
+
+        # Identity
+        @page.to_absolute(@page.url).should == @page.url
+        @page.to_absolute("").should == @page.url
+
+        # Root-ness
+        @page.to_absolute("/").should == URI("#{SPEC_DOMAIN}")
+
+        # Relativeness
+        relative_path = "a/relative/path"
+        @page.to_absolute(relative_path).should == URI("#{SPEC_DOMAIN}#{relative_path}")
+
+        deep_page = @http.fetch_page(FakePage.new('home/deep', :links => '1').url)
+        upward_relative_path = "../a/relative/path"
+        deep_page.to_absolute(upward_relative_path).should == URI("#{SPEC_DOMAIN}#{relative_path}")
+
+        # The base URL case
+        base_path = "path/to/base_url/"
+        base = "#{SPEC_DOMAIN}#{base_path}"
+        page = @http.fetch_page(FakePage.new('home', {:base => base}).url)
+
+        # Identity
+        page.to_absolute(page.url).should == page.url
+        # It should revert to the base url
+        page.to_absolute("").should_not == page.url
+
+        # Root-ness
+        page.to_absolute("/").should == URI("#{SPEC_DOMAIN}")
+
+        # Relativeness
+        relative_path = "a/relative/path"
+        page.to_absolute(relative_path).should == URI("#{base}#{relative_path}")
+
+        upward_relative_path = "../a/relative/path"
+        upward_base = "#{SPEC_DOMAIN}path/to/"
+        page.to_absolute(upward_relative_path).should == URI("#{upward_base}#{relative_path}")
+      end
     end
 
   end


### PR DESCRIPTION
Hi,

Thanks for the useful gem!
This PR suppresses the below errors.

```
/BUNDLE_ROOT/ruby/2.7.0/gems/anemone-0.7.2/lib/anemone/page.rb:157: warning: URI.unescape is obsolete
/BUNDLE_ROOT/ruby/2.7.0/gems/anemone-0.7.2/lib/anemone/page.rb:157: warning: URI.escape is obsolete
```